### PR TITLE
removed a VA statewide polling place in the csv example

### DIFF
--- a/vip_5.1_csv_examples/vip_5.1_csv_examples/state.txt
+++ b/vip_5.1_csv_examples/vip_5.1_csv_examples/state.txt
@@ -1,2 +1,2 @@
 election_administration_id,external_identifier_type,external_identifier_othertype,external_identifier_value,name,polling_location_ids,id
-ea123,ocd-id,,"ocd-division/country:us/state:va",Virginia,"poll001 poll002 poll003",st51
+ea123,ocd-id,,"ocd-division/country:us/state:va",Virginia,,st51


### PR DESCRIPTION
Very few states have statewide polling places. (Virginia does not). This example was modeling a particularly unlikely edge case in a way that caused some confusion to users studying this model.
